### PR TITLE
mkdir requires callback, using mkdirSync to fix

### DIFF
--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -99,7 +99,7 @@ const downloadFlywaySource = exports.downloadFlywaySource = source => {
     return Promise.resolve(source.filename);
   } else {
     (0, _rimraf2.default)(downloadDir, () => {
-      _fs2.default.mkdir(downloadDir);
+      _fs2.default.mkdirSync(downloadDir);
     });
   }
 
@@ -212,7 +212,7 @@ const makeBinLink = exports.makeBinLink = libDir => {
         _fs2.default.unlinkSync(_path2.default.join(binDir, 'flyway'));
         _fs2.default.symlinkSync(_path2.default.join(flywayDir, 'flyway'), _path2.default.join(binDir, 'flyway'));
       } else {
-        _fs2.default.mkdir(binDir);
+        _fs2.default.mkdirSync(binDir);
         _fs2.default.symlinkSync(_path2.default.join(flywayDir, 'flyway'), _path2.default.join(binDir, 'flyway'));
       }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -60,7 +60,7 @@ export const downloadFlywaySource = (source) => {
     return Promise.resolve(source.filename)
   } else {
     rimraf(downloadDir, () => {
-      fs.mkdir(downloadDir)
+      fs.mkdirSync(downloadDir)
     })
   }
 
@@ -174,7 +174,7 @@ export const makeBinLink = (libDir) => {
         fs.unlinkSync(path.join(binDir, 'flyway'))
         fs.symlinkSync(path.join(flywayDir, 'flyway'), path.join(binDir, 'flyway'))
       } else {
-        fs.mkdir(binDir)
+        fs.mkdirSync(binDir)
         fs.symlinkSync(path.join(flywayDir, 'flyway'), path.join(binDir, 'flyway'))
       }
 


### PR DESCRIPTION
My guess is that newer versions of Node introduced a breaking change that `mkdir` requires a callback function. Tested this theory by swapping to `mkdirSync` and my error went away.

Before this change I was getting the following error when trying to install _flywaydb-cli:_
```
error /Users/twilliams/dev/xkit/backend/node_modules/flywaydb-cli: Command failed.
Exit code: 1
Command: node dist/installer.js
Arguments: 
Directory: /Users/twilliams/dev/xkit/backend/node_modules/flywaydb-cli
Output:
Downloading https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/5.1.4/flyway-commandline-5.1.4-macosx-x64.tar.gz
Saving to /Users/twilliams/dev/xkit/backend/node_modules/flywaydb-cli/tmp/flyway-commandline-5.1.4-macosx-x64.tar.gz
fs.js:141
    throw new ERR_INVALID_CALLBACK();
    ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:141:11)
    at Object.mkdir (fs.js:720:16)
    at /Users/twilliams/dev/xkit/backend/node_modules/flywaydb-cli/dist/utils/index.js:102:20
    at next (/Users/twilliams/dev/xkit/backend/node_modules/rimraf/rimraf.js:75:7)
    at CB (/Users/twilliams/dev/xkit/backend/node_modules/rimraf/rimraf.js:111:9)
    at /Users/twilliams/dev/xkit/backend/node_modules/rimraf/rimraf.js:137:14
    at FSReqWrap.oncomplete (fs.js:158:21)
```