### PR TITLE
Now using a relative path to symlink flyway binary

### DIFF
--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -206,14 +206,15 @@ const makeBinLink = exports.makeBinLink = libDir => {
     let versionDirs = flywayVersionDir(libDir);
     let flywayDir = _path2.default.join(libDir, versionDirs[0]);
     let binDir = _path2.default.join(__dirname, '../../', 'bin');
+    let relPath = _path2.default.relative(binDir, flywayDir);
 
     if (_fs2.default.existsSync(flywayDir)) {
       if (_fs2.default.existsSync(binDir)) {
         _fs2.default.unlinkSync(_path2.default.join(binDir, 'flyway'));
-        _fs2.default.symlinkSync(_path2.default.join(flywayDir, 'flyway'), _path2.default.join(binDir, 'flyway'));
+        _fs2.default.symlinkSync(_path2.default.join(relPath, 'flyway'), _path2.default.join(binDir, 'flyway'));
       } else {
         _fs2.default.mkdirSync(binDir);
-        _fs2.default.symlinkSync(_path2.default.join(flywayDir, 'flyway'), _path2.default.join(binDir, 'flyway'));
+        _fs2.default.symlinkSync(_path2.default.join(relPath, 'flyway'), _path2.default.join(binDir, 'flyway'));
       }
 
       resolve();

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -168,14 +168,15 @@ export const makeBinLink = (libDir) => {
     let versionDirs = flywayVersionDir(libDir)
     let flywayDir = path.join(libDir, versionDirs[0])
     let binDir = path.join(__dirname, '../../', 'bin')
+    let relPath = path.relative(binDir, flywayDir);
 
     if (fs.existsSync(flywayDir)) {
       if (fs.existsSync(binDir)) {
         fs.unlinkSync(path.join(binDir, 'flyway'))
-        fs.symlinkSync(path.join(flywayDir, 'flyway'), path.join(binDir, 'flyway'))
+        fs.symlinkSync(path.join(relPath, 'flyway'), path.join(binDir, 'flyway'))
       } else {
         fs.mkdirSync(binDir)
-        fs.symlinkSync(path.join(flywayDir, 'flyway'), path.join(binDir, 'flyway'))
+        fs.symlinkSync(path.join(relPath, 'flyway'), path.join(binDir, 'flyway'))
       }
 
       resolve()


### PR DESCRIPTION
Since the current symlink is absolute, this won't run properly within docker images. This change makes the symlink relative.