### PR TITLE
Delete specific broken symlink in jre directory before copy to bin, to avoid it to fail

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -202,7 +202,9 @@ export const copyToBin = libDir => {
     if (fs.existsSync(flywayDir)) {
       rimraf.sync(path.join(__dirname, "../../", "bin"));
 
-      fs.removeSync(path.join(flywayDir, "jre", "lib", "amd64", "server", "libjsig.so")) // Broken link, we need to delete it to avoid the copy to fail
+      if (fs.existsSync(path.join(flywayDir, "jre", "lib", "amd64"))) {
+        fs.removeSync(path.join(flywayDir, "jre", "lib", "amd64", "server", "libjsig.so")) // Broken link, we need to delete it to avoid the copy to fail
+      }
       fs.copySync(flywayDir, binDir);
 
       resolve();

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -201,6 +201,8 @@ export const copyToBin = libDir => {
 
     if (fs.existsSync(flywayDir)) {
       rimraf.sync(path.join(__dirname, "../../", "bin"));
+
+      fs.removeSync(path.join(flywayDir, "jre", "lib", "amd64", "server", "libjsig.so")) // Broken link, we need to delete it to avoid the copy to fail
       fs.copySync(flywayDir, binDir);
 
       resolve();


### PR DESCRIPTION
For an unknown reason, flyway comes with a broken symlink in its jre directory. This makes the copy to bin folder fail, as fs-extra doesn't handle such cases.
This "quickfix" removes the broken symlink before copy. A better way would be to automatically detect broken symlinks and just ignore them.