### PR TITLE
Use npm cache to reduce duplicate downloads

### DIFF
--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -95,12 +95,17 @@ const getReleaseSource = exports.getReleaseSource = () => (0, _requestPromise2.d
   return sources[_os2.default.platform()];
 });
 
+// copied from https://github.com/getsentry/sentry-cli/blob/c65df4fba17101e60e8c31f378f6001b514e5a42/scripts/install.js#L123-L131
+const getNpmCache = () => {
+  return env.npm_config_cache || env.npm_config_cache_folder || env.npm_config_yarn_offline_mirror || (env.APPDATA ? _path2.default.join(env.APPDATA, 'npm-cache') : _path2.default.join(_os2.default.homedir(), '.npm'));
+};
+
 /**
  * @param {any} source
  * @returns source.filename
  */
 const downloadFlywaySource = exports.downloadFlywaySource = source => {
-  let downloadDir = _path2.default.join(__dirname, "../../", "tmp");
+  let downloadDir = _path2.default.join(getNpmCache(), 'flywaydb-cli');
 
   if (!source) {
     throw new Error("Your platform is not supported");
@@ -108,6 +113,7 @@ const downloadFlywaySource = exports.downloadFlywaySource = source => {
 
   source.filename = _path2.default.join(downloadDir, source.filename);
   if (_fsExtra2.default.existsSync(source.filename)) {
+    console.log("Cached file exists, skipping download", source.filename);
     return Promise.resolve(source.filename);
   } else {
     (0, _rimraf2.default)(downloadDir, () => {
@@ -247,6 +253,5 @@ const flywayVersionDir = libDir => {
 };
 
 const cleanupDirs = exports.cleanupDirs = () => {
-  _rimraf2.default.sync(_path2.default.join(__dirname, "../../", "tmp"));
   _rimraf2.default.sync(_path2.default.join(__dirname, "../../", "lib"));
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -65,12 +65,22 @@ export const getReleaseSource = () =>
     return sources[os.platform()];
   });
 
+// copied from https://github.com/getsentry/sentry-cli/blob/c65df4fba17101e60e8c31f378f6001b514e5a42/scripts/install.js#L123-L131
+const getNpmCache = () => {
+  return (
+    env.npm_config_cache ||
+    env.npm_config_cache_folder ||
+    env.npm_config_yarn_offline_mirror ||
+    (env.APPDATA ? path.join(env.APPDATA, 'npm-cache') : path.join(os.homedir(), '.npm'))
+  );
+}
+
 /**
  * @param {any} source
  * @returns source.filename
  */
 export const downloadFlywaySource = source => {
-  let downloadDir = path.join(__dirname, "../../", "tmp");
+  let downloadDir = path.join(getNpmCache(), 'flywaydb-cli');
 
   if (!source) {
     throw new Error("Your platform is not supported");
@@ -78,6 +88,7 @@ export const downloadFlywaySource = source => {
 
   source.filename = path.join(downloadDir, source.filename);
   if (fs.existsSync(source.filename)) {
+    console.log("Cached file exists, skipping download", source.filename);
     return Promise.resolve(source.filename);
   } else {
     rimraf(downloadDir, () => {
@@ -224,6 +235,5 @@ const flywayVersionDir = libDir => {
 };
 
 export const cleanupDirs = () => {
-  rimraf.sync(path.join(__dirname, "../../", "tmp"));
   rimraf.sync(path.join(__dirname, "../../", "lib"));
 };

--- a/test/cleanupDirs.test.js
+++ b/test/cleanupDirs.test.js
@@ -3,7 +3,5 @@ import sinon from "sinon";
 import rewire from "rewire";
 let utils = rewire("../src/utils");
 
-test.todo("delete tmp dir success");
-test.todo("delete tmp dir error");
 test.todo("delete lib dir success");
 test.todo("delete lib dir error");


### PR DESCRIPTION
## Why
- flyway binary is large and takes a while to download
- my version of flyway rarely changes, but my CI ends up downloading the binary many times per day (on every PR)

## How
- download to npm cache instead of custom `tmp` dir
- npm cache is widely used to download/cache binaries and has [native support on Github Actions](https://github.com/actions/setup-node#caching-global-packages-data)) 

## Verification
- 1st install takes 40-50s:
```sh
  > flywaydb-cli@0.8.3 install /Users/alden/Developer/aldenquimby/flywaydb-cli
  > node dist/installer.js

  Downloading https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/9.2.0/flyway-commandline-9.2.0-macosx-x64.tar.gz
  Saving to /Users/alden/.npm/flywaydb-cli/flyway-commandline-9.2.0-macosx-x64.tar.gz
    [========================================] 98%
  Received 130.52 MB total.
```
- 2nd install takes 8-10s:
```sh
  > flywaydb-cli@0.8.3 install /Users/alden/Developer/aldenquimby/flywaydb-cli
  > node dist/installer.js

  Cached file exists, skipping download /Users/alden/.npm/flywaydb-cli/flyway-commandline-9.2.0-macosx-x64.tar.gz
```
- `npm run test` passes (after removing empty file `readDotFlywayFile.test.js`)
```sh
> flywaydb-cli@0.8.3 test /Users/alden/Developer/aldenquimby/flywaydb-cli
> nyc ava

  5 passed
  11 todo

----------|----------|----------|----------|----------|----------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------|----------|----------|----------|----------|----------------|
All files |    36.84 |    17.07 |    26.32 |    36.84 |                |
 index.js |    36.84 |    17.07 |    26.32 |    36.84 |... 232,234,238 |
----------|----------|----------|----------|----------|----------------|
```